### PR TITLE
feat: ignore Xonsh scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Default options are:
     "shellcheck.customArgs": [],
     "shellcheck.ignorePatterns": {
         "**/*.xonshrc": true,
-		"**/*.xsh": true,
+        "**/*.xsh": true,
         "**/*.zsh": true,
         "**/*.zshrc": true,
         "**/zshrc": true,

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Default options are:
     "shellcheck.exclude": [],
     "shellcheck.customArgs": [],
     "shellcheck.ignorePatterns": {
+        "**/*.xonshrc": true,
+		"**/*.xsh": true,
         "**/*.zsh": true,
         "**/*.zshrc": true,
         "**/zshrc": true,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "shellcheck",
     "displayName": "ShellCheck",
     "description": "Integrates ShellCheck into VS Code, a linter for Shell scripts.",
-    "version": "0.15.4",
+    "version": "0.15.3",
     "publisher": "timonwong",
     "author": "Timon Wong <timon86.wang@gmail.com> (https://github.com/timonwong)",
     "contributors": [

--- a/package.json
+++ b/package.json
@@ -115,6 +115,8 @@
                         ]
                     },
                     "default": {
+                        "**/*.xonshrc": true,
+                        "**/*.xsh": true,
                         "**/*.zsh": true,
                         "**/*.zshrc": true,
                         "**/zshrc": true,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "shellcheck",
     "displayName": "ShellCheck",
     "description": "Integrates ShellCheck into VS Code, a linter for Shell scripts.",
-    "version": "0.15.3",
+    "version": "0.15.4",
     "publisher": "timonwong",
     "author": "Timon Wong <timon86.wang@gmail.com> (https://github.com/timonwong)",
     "contributors": [


### PR DESCRIPTION
Was wondering why my jnoortheen.xonsh vscode editor extension was showing shellcheck  errors vs the xonsh IDE ones and stuff. I then realized the default doesn't exclude the xonsh shell type files for shellcheck. 

This PR will exclude those files so that having both installed will not show the shellcheck errors when editing xonsh scripts and rc files.

Reference:
https://xon.sh/bash_to_xsh.html
"For shell scripts, the recommended file extension is xsh, and shebang line is #!/usr/bin/env xonsh."

