### PR TITLE
feat: provide inline links to wiki on hover

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -288,10 +288,11 @@ export default class ShellCheckProvider implements vscode.CodeActionProvider {
       }
 
       if (
-        typeof diagnostic.code === "string" &&
-        diagnostic.code.startsWith("SC")
+        typeof diagnostic.code === "object" &&
+        typeof diagnostic.code.value === "string" &&
+        diagnostic.code.value.startsWith("SC")
       ) {
-        const ruleId = diagnostic.code;
+        const ruleId = diagnostic.code.value;
         const title = `Show ShellCheck Wiki for ${ruleId}`;
         const action = new vscode.CodeAction(
           title,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -140,7 +140,12 @@ class JsonParserMixin {
     const severity = convertSeverity(problem.level);
     const diagnostic = new vscode.Diagnostic(range, problem.message, severity);
     diagnostic.source = "shellcheck";
-    diagnostic.code = `SC${problem.code}`;
+    diagnostic.code = {
+      value: `SC${problem.code}`,
+      target: vscode.Uri.parse(
+        `https://www.shellcheck.net/wiki/SC${problem.code}`
+      ),
+    };
     diagnostic.tags = scCodeToDiagnosticTags(problem.code);
     return diagnostic;
   }

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -26,6 +26,13 @@ suite("Shellcheck extension", () => {
     const diagnostics = vscode.languages.getDiagnostics(editor.document.uri);
     assert.strictEqual(ext.isActive, true, "Extension should be activated");
     assert.strictEqual(diagnostics.length, 1);
-    assert.strictEqual(diagnostics[0].code, "SC2034");
+    if (typeof diagnostics[0].code !== "object") {
+      throw new Error("diagnostic.code should be an object");
+    }
+    assert.strictEqual(diagnostics[0].code?.value, "SC2034");
+    assert.strictEqual(
+      diagnostics[0].code?.target.toString(),
+      "https://www.shellcheck.net/wiki/SC2034"
+    );
   });
 });


### PR DESCRIPTION
Add a link to the [ShellCheck Wiki](https://www.shellcheck.net/wiki/Home) when you hover a ShellCheck error/warning.

# Notes

* We already had a `Show ShellCheck wiki for ...` code action but that requires an extra click
* More info at https://code.visualstudio.com/api/references/vscode-api#Diagnostic

# Before
![Screen Shot 2022-08-14 at 12 00 31 PM](https://user-images.githubusercontent.com/127199/184534641-3c4d0548-df21-4767-b242-4de79ea87e68.png)

# After
(lint id is clickable)
![Screen Shot 2022-08-14 at 1 28 41 PM](https://user-images.githubusercontent.com/127199/184534639-6e80a6f6-0f47-481c-b55e-9e4e8ed7fe8f.png)