### PR TITLE
format: add prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "useTabs": false
+}


### PR DESCRIPTION
I noticed the [vscode-prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) extension wasn't working out of the box. The root cause was that there was no Prettier configuration file.