### PR TITLE
feat: allow linting for domain-specific shell languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ For example, you can place it at `shellcheck.sh` in the root of your workspace a
 }
 ```
 
+## Advanced usage
+
+### Integrating other VS Code extensions
+
+This extension provides a small API, which allows other VS Code extensions to interact with the ShellCheck extension. For details, see [API.md](./doc/API.md).
+
 ## Acknowledgements
 
 This extension is based on [@hoovercj's Haskell Linter](https://github.com/hoovercj/vscode-haskell-linter).

--- a/doc/API.md
+++ b/doc/API.md
@@ -1,0 +1,51 @@
+# API
+
+The ShellCheck extension provides a small API, which allows other VS Code extensions to interact with the ShellCheck extension.
+
+The API offers a single function named `registerDocumentFilter`.
+
+## API function: registerDocumentFilter
+
+The `registerDocumentFilter` function allows other VS Code extensions to register their own shell-based language IDs with the ShellCheck extension.
+
+### Prerequisites
+
+To make the ShellCheck extension known to your own VS Code extension, add `timonwong.shellcheck` to the `extensionDependencies` list in your `package.json`:
+
+```json
+// Add this to your package.json
+"extensionDependencies": [
+  "timonwong.shellcheck"
+]
+```
+
+### Interface
+
+The interface of the API is:
+
+```ts
+import { Disposable, DocumentFilter } from "vscode";
+
+// Copy this interface into your own extension
+export interface ShellCheckExtensionApiVersion1 {
+  registerDocumentFilter: (documentFilter: DocumentFilter) => Disposable;
+}
+```
+
+### Example
+
+An example API call to `registerDocumentFilter`:
+
+```ts
+import { Disposable, DocumentFilter, extensions } from "vscode";
+
+// Run these commands in your own extension
+const MY_FILTER: DocumentFilter = { language: "my-language-id" };
+const shellCheckExtension = extensions.getExtension("timonwong.shellcheck");
+const subscription =
+  shellCheckExtension?.exports?.apiVersion1?.registerDocumentFilter(MY_FILTER);
+```
+
+## See also
+
+- https://code.visualstudio.com/api/references/vscode-api#extensions

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,11 @@
+import * as vscode from "vscode";
+
+export interface ShellCheckExtensionApiVersion1 {
+  registerDocumentFilter: (
+    documentFilter: vscode.DocumentFilter
+  ) => vscode.Disposable;
+}
+
+export interface ShellCheckExtensionApi {
+  apiVersion1: ShellCheckExtensionApiVersion1;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,11 @@
 import * as vscode from "vscode";
+import { ShellCheckExtensionApi } from "./api";
 import { LinkifyProvider } from "./linkify";
 import ShellCheckProvider from "./linter";
 
-export function activate(context: vscode.ExtensionContext): void {
+export function activate(
+  context: vscode.ExtensionContext
+): ShellCheckExtensionApi {
   const linter = new ShellCheckProvider(context);
   context.subscriptions.push(linter);
 
@@ -12,6 +15,9 @@ export function activate(context: vscode.ExtensionContext): void {
     new LinkifyProvider()
   );
   context.subscriptions.push(linker);
+
+  // public API surface
+  return linter.provideApi();
 }
 
 export function deactivate(): void {}


### PR DESCRIPTION
This PR introduces [an API endpoint](https://github.com/claui/vscode-shellcheck/blob/6f94d4fcd446fe9068ebb3bf3024097ea6a96769/doc/API.md) to the ShellCheck extension.

```ts
export interface ShellCheckExtensionApiVersion1 {
  registerDocumentFilter: (documentFilter: DocumentFilter) => Disposable;
}
```

Other VS Code extensions can use that API to tell the ShellCheck extension about shell-based domain-specific languages (DSLs) whose language ID is not `shellscript`.

This enables linting for all text documents that match the filter, especially derived languages whose language IDs are not `shellscript`.

## Rationale

There are a couple of such DSLs, e.g. [PKGBUILD](https://wiki.archlinux.org/title/PKGBUILD) files.  
If a third-party extension supports such a domain-specific language, it makes sense for that extension to use a dedicated language ID other than `shellscript`, because this is required for some features.

## Usage example

```ts
import { Disposable, DocumentFilter, extensions } from "vscode";

// Run these commands in your own extension
const MY_FILTER: DocumentFilter = { language: "my-language-id" };
const shellCheckExtension = extensions.getExtension("timonwong.shellcheck");
const subscription =
  shellCheckExtension?.exports?.apiVersion1?.registerDocumentFilter(MY_FILTER);
```

## Real-world example

The VS Code extension [AUR packaging](https://github.com/claui/vscode-aur-packaging) contributes features for `PKGBUILD` files in the [Arch User Repository](https://aur.archlinux.org/).

One major feature of that extension is PKGBUILD-specific [configuration defaults](https://github.com/claui/vscode-aur-packaging/blob/fabeb128f393f7b32eb4c190d7d57c2dce81993f/extension/package.json#L33-L42). Those configuration defaults serve to remove dozens of unhelpful ShellCheck findings from PKGBUILD files, but that requires [a dedicated language ID](https://code.visualstudio.com/api/references/contribution-points#contributes.configurationDefaults) (`aur-pkgbuild` in this example.)

## Alternative solutions

I have explored a couple of alternative solutions but found them all severely lacking: `.shellcheckrc` files and `.vscode/settings.json`s are not allowed in the AUR; nor would such files be remotely practical, given that the AUR has tens of thousands of Git repositories, each of them holding a single PKGBUILD file. That’s why I’ve written the _AUR packaging_ extension.

## Caveats

While this PR is a useful first step (merging it will enable ShellCheck for derived languages in VS Code for the first time), it’s not enough to fix the issue with excessive ShellCheck warnings in `PKGBUILD`s.  
This is mainly because the ShellCheck extension doesn’t support VS Code’s workspace-level, workspace-folder-level and language-level configuration yet.

For a sneak preview of a working prototype with those issues fixed as well, please see #697.