### PR TITLE
fix: prevent endless feedback loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Default options are:
     "**/zshenv": true,
     "**/*.zsh-theme": true
   },
-  "shellcheck.ignoreFileSchemes": ["git", "gitfs"]
+  "shellcheck.ignoreFileSchemes": ["git", "gitfs", "output"]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -169,7 +169,8 @@
           "scope": "application",
           "default": [
             "git",
-            "gitfs"
+            "gitfs",
+            "output"
           ]
         },
         "shellcheck.useWorkspaceRootAsCwd": {

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -222,7 +222,7 @@ export default class ShellCheckProvider implements vscode.CodeActionProvider {
         .map((arg) => substitutePath(arg)),
       ignorePatterns: section.get("ignorePatterns", {}),
       ignoreFileSchemes: new Set(
-        section.get("ignoreFileSchemes", ["git", "gitfs"])
+        section.get("ignoreFileSchemes", ["git", "gitfs", "output"])
       ),
       useWorkspaceRootAsCwd: section.get("useWorkspaceRootAsCwd", false),
       enableQuickFix: section.get("enableQuickFix", false),


### PR DESCRIPTION
This PR adds the `output` scheme to the default `shellcheck.ignoreFileSchemes` list.

If `shellcheck.run` is set to `onType` (the default), writing to the log may cause an endless feedback loop: VS Code treats the output channel as a text document, and will emit a document-change event for every single line logged to any output channel, which in turn may lead to our handler logging even more lines, and so on.

This new check is arguably redundant: the language of the channel can never be Shell, which means the existing `isAllowedTextDocument` check happens to cover this case already, albeit by accident.

I still feel that there’s value in declaring this explicitly rather than relying on accidental behavior.
