### PR TITLE
fix: use named diagnostic collection

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -101,7 +101,8 @@ export default class ShellCheckProvider implements vscode.CodeActionProvider {
     this.delayers = Object.create(null);
     this.settingsByUri = new Map();
     this.toolStatusByPath = new Map();
-    this.diagnosticCollection = vscode.languages.createDiagnosticCollection();
+    this.diagnosticCollection =
+      vscode.languages.createDiagnosticCollection("shellcheck");
     this.codeActionCollection = new Map();
     this.additionalDocumentFilters = new Set();
 


### PR DESCRIPTION
Creating named diagnostic collection correctly set the "owner" field.

Closes #666
