### PR TITLE
docs: tweak syntax highlighting in API.md

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -12,7 +12,7 @@ The `registerDocumentFilter` function allows other VS Code extensions to regist
 
 To make the ShellCheck extension known to your own VS Code extension, add `timonwong.shellcheck` to the `extensionDependencies` list in your `package.json`:
 
-```json
+```jsonc
 // Add this to your package.json
 "extensionDependencies": [
   "timonwong.shellcheck"


### PR DESCRIPTION
We don't need the comment on the JSON flagged here; switch that block from json to jsonc.