### PR TITLE
fix: windows x86 (32 bits) vsix does not contain the binary

### DIFF
--- a/bindl.config.js
+++ b/bindl.config.js
@@ -36,7 +36,7 @@ module.exports = {
     },
     {
       platform: "win32",
-      arch: "x32",
+      arch: "ia32",
       url: `${officialReleaseUrl}.zip`,
       files: [{ source: "shellcheck.exe", target: "shellcheck.exe" }],
     },


### PR DESCRIPTION
Follows-up: #805
