### PR TITLE
feat: add shellcheck.collectDiagnostics command 

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,10 @@
       {
         "command": "shellcheck.runLint",
         "title": "ShellCheck: Run Linting"
+      },
+      {
+        "command": "shellcheck.collectDiagnostics",
+        "title": "ShellCheck: Collect Diagnostics For Current Document"
       }
     ],
     "configuration": {

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -364,7 +364,7 @@ export default class ShellCheckProvider implements vscode.CodeActionProvider {
     if (toolStatus && toolStatus.ok) {
       output.push(
         `- Version: \`${toolStatus.version}\``,
-        `- bundled: \`${settings.executable.bundled}\``,
+        `- Bundled: \`${settings.executable.bundled}\``,
         ""
       );
     } else {


### PR DESCRIPTION
Partial #908

To activate, bring up the command palette and choose `ShellCheck: Collect Diagnostics For Current Document`

<img width="1138" alt="image" src="https://user-images.githubusercontent.com/1398228/231684957-ed6e457b-54db-4ea2-8eef-516dc8cbc58c.png">
