### PR TITLE
fix: cannot read properties of null on startup

### DIFF
--- a/src/linter.ts
+++ b/src/linter.ts
@@ -143,9 +143,13 @@ export default class ShellCheckProvider implements vscode.CodeActionProvider {
   }
 
   private onDidCloseTextDocument(textDocument: vscode.TextDocument) {
-    this.setResultCollections(textDocument.uri);
-    this.settingsByUri.delete(textDocument.uri.toString());
-    delete this.delayers[textDocument.uri.toString()];
+    // For some reason, this is not always set. See:
+    // https://github.com/vscode-shellcheck/vscode-shellcheck/issues/1039
+    if (this) {
+      this.setResultCollections(textDocument.uri);
+      this.settingsByUri.delete(textDocument.uri.toString());
+      delete this.delayers[textDocument.uri.toString()];
+    }
   }
 
   private onDidChangeConfiguration(e: vscode.ConfigurationChangeEvent) {


### PR DESCRIPTION
I don't understand why this would be needed. @timonwong, do you have any clue by any chance?

@reporter123 you can help us out by testing if this PR fixes your issue or not.

Closes #1039 