### PR TITLE
fix: add fish scripts to the default ignore patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
             "description": "The glob pattern to match file paths against. Set to true or false to enable or disable the pattern."
           },
           "default": {
+            "**/*.fish": true,
             "**/*.xonshrc": true,
             "**/*.xsh": true,
             "**/*.zsh": true,


### PR DESCRIPTION
Shellcheck doesn't support fish scripts, so they should be ignored