### PR TITLE
build(deps): drop support for Windows 32 bits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,9 +42,6 @@ jobs:
             target: win32-x64
             npm_config_arch: x64
           - os: windows-latest
-            target: win32-ia32
-            npm_config_arch: ia32
-          - os: windows-latest
             target: win32-arm64
             npm_config_arch: arm
           - os: ubuntu-latest

--- a/licenses/shellcheck-LICENSE.txt
+++ b/licenses/shellcheck-LICENSE.txt
@@ -1,13 +1,3 @@
-Employer mandated disclaimer:
-
-  I am providing code in the repository to you under an open source license.
-  Because this is my personal repository, the license you receive to my code is
-  from me and other individual contributors, and not my employer (Facebook).
-
-  - Vidar "koala_man" Holen
-
-----
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
@@ -681,4 +671,4 @@ into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<https://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -116,13 +116,8 @@ async function getExecutable(
   if (!executablePath) {
     // Use bundled binaries (maybe)
     const suffix = process.platform === "win32" ? ".exe" : "";
-    const osarch =
-      // Remove after https://github.com/microsoft/vscode-vsce/issues/786 is fixed
-      process.platform === "win32" && process.arch === "arm"
-        ? "ia32"
-        : process.arch;
     executablePath = context.asAbsolutePath(
-      `./binaries/${process.platform}/${osarch}/shellcheck${suffix}`,
+      `./binaries/${process.platform}/${process.arch}/shellcheck${suffix}`,
     );
     try {
       await fs.promises.access(executablePath, fs.constants.X_OK);


### PR DESCRIPTION
Drop support for Windows 32 bits, since the Visual Studio Marketplace no longer accepts publishing extensions for such target.

Also update the shellcheck LICENSE to the latest version.