### PR TITLE
fix: not linking comments without SC prefix

### DIFF
--- a/src/linkify.ts
+++ b/src/linkify.ts
@@ -31,7 +31,7 @@ export class LinkifyProvider implements vscode.DocumentLinkProvider {
     line: string,
     result: vscode.DocumentLink[],
   ) {
-    const pattern = /\bSC\d{4}\b/g;
+    const pattern = /\b(SC)?\d{4}\b/g;
     const matches = line.matchAll(pattern);
     for (const match of matches) {
       const ruleId = match[0];

--- a/test/linkify.test.ts
+++ b/test/linkify.test.ts
@@ -18,6 +18,19 @@ echo $SHELL
 eval \`uname -r\`
 
 # shellcheck disable=SC1013
+
+# No SC prefix:
+
+# shellcheck disable=1014
+echo $SHELL
+
+ #  shellcheck disable=1015
+echo $SHELL
+
+ #   shellcheck   disable=1016
+eval \`uname -r\`
+
+# shellcheck disable=1017
 `,
       language: "shellscript",
     });
@@ -30,7 +43,7 @@ eval \`uname -r\`
       } as vscode.CancellationToken);
 
     assert.ok(links);
-    assert.strictEqual(links.length, 4);
+    assert.strictEqual(links.length, 8);
     for (const [i, link] of links.entries()) {
       assert.strictEqual(link.target?.authority, "www.shellcheck.net");
       assert.strictEqual(link.target?.path, `/wiki/SC101${i}`);


### PR DESCRIPTION
Thanks @TriMoon for the report and the detailed analysis.

Fixes #1558
